### PR TITLE
CI: relative action refs, actionlint, docs, and act config

### DIFF
--- a/.github/actions/setup-bun/action.yml
+++ b/.github/actions/setup-bun/action.yml
@@ -1,0 +1,9 @@
+name: "Setup Bun & Install"
+description: "Installs Bun and dependencies with frozen lockfile"
+runs:
+  using: "composite"
+  steps:
+    - uses: oven-sh/setup-bun@v2
+    - name: Install deps (frozen)
+      shell: bash
+      run: bun install --frozen-lockfile

--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -1,0 +1,20 @@
+name: actionlint
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/*.yml"
+      - ".github/workflows/*.yaml"
+      - ".github/actions/**"
+      - "AGENTS.md"
+jobs:
+  actionlint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - name: Run actionlint
+        uses: reviewdog/action-actionlint@v1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          reporter: github-pr-check
+          filter_mode: nofilter
+          actionlint_flags: "-color -shellcheck="

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,10 @@
+name: lint
+on:
+  workflow_call:
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: ./.github/actions/setup-bun
+      - run: bun x biome ci .

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,23 @@
+name: release
+on:
+  workflow_call:
+    secrets:
+      NPM_TOKEN:
+        required: true
+permissions:
+  contents: write
+  pull-requests: write
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: ./.github/actions/setup-bun
+      - name: Create Release PR or Publish
+        uses: changesets/action@v1
+        with:
+          version: bunx changeset version
+          publish: bunx changeset publish
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,11 @@
+name: test
+on:
+  workflow_call:
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: ./.github/actions/setup-bun
+      - name: Vitest
+        run: bun x vitest run --coverage

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -1,0 +1,11 @@
+name: typecheck
+on:
+  workflow_call:
+jobs:
+  typecheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: ./.github/actions/setup-bun
+      - name: TypeScript (noEmit fallback)
+        run: bun x tsc -b || bun x tsc --noEmit

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,43 @@
+# Repository Guidelines
+
+## Project Structure and Module Organization
+- This repository serves as an aggregation of reusable GitHub Actions. It does not contain source code for applications or libraries.
+- Common workflows are located in `.github/workflows/`: `lint.yml` / `test.yml` / `typecheck.yml` / `release.yml`.
+- `.github/actions/setup-bun/` contains a composite action that installs Bun and runs `bun install --frozen-lockfile`.
+
+## Build, Test, and Development Commands
+- No build artifact is produced here; validate changes locally with `act`.
+- Example usage (Apple Silicon: add `--container-architecture linux/amd64`):
+  - `act -j lint -W .github/workflows/lint.yml --container-architecture linux/amd64`
+  - `act -j test -W .github/workflows/test.yml --container-architecture linux/amd64`
+  - `act -j typecheck -W .github/workflows/typecheck.yml --container-architecture linux/amd64`
+- Optional static analysis: `actionlint`.
+
+## Local act Configuration
+- Copy `actrc.example` to your OS‑specific config to omit the architecture flag:
+  - macOS: `$HOME/Library/Application Support/act/actrc`
+  - Linux: `$HOME/.actrc`
+- The example sets `--container-architecture linux/amd64` and a default image mapping.
+
+## Coding Standards and Naming Conventions
+- YAML uses 2‑space indentation; filenames are `kebab-case.yml`.
+- Job IDs are lowercase and concise (e.g., `lint`, `test`); step `name` is human‑readable.
+- External actions should use stable tags (e.g., `actions/checkout@v5`). The internal composite action is referenced relatively: `./.github/actions/setup-bun` so it works both with `act` and on GitHub.
+
+## Testing Guidelines
+- For changes, verify basic cases using `act` and optionally run tests in a dedicated sandbox repository.
+- Example call syntax for downstream repositories:
+  ```yaml
+  jobs:
+    lint:      { uses: listee-dev/listee-ci/.github/workflows/lint.yml@v1 }
+    test:      { uses: listee-dev/listee-ci/.github/workflows/test.yml@v1 }
+    typecheck: { uses: listee-dev/listee-ci/.github/workflows/typecheck.yml@v1 }
+  ```
+
+## Committing and Pull Request Process
+- Conventional Commits format is recommended (e.g., `feat(lint): Enhance CI for Biome`).
+- PRs should include purpose, key changes, impact scope, and verification instructions (`act` command examples). Link relevant issues.
+
+## Security and Configuration Notes
+- `release.yml` requires the `NPM_TOKEN` to be provided by the caller. Permissions are minimized to `contents` and `pull-requests`.
+- Do not log sensitive information. Using stable tags helps reduce supply chain risks.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,53 @@
 # listee-ci
+
+[![actionlint](https://github.com/listee-dev/listee-ci/actions/workflows/actionlint.yml/badge.svg?branch=main)](https://github.com/listee-dev/listee-ci/actions/workflows/actionlint.yml)
+[![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
+
 Reusable GitHub Actions workflows for the listee-dev organization — Bun, Biome, Vitest, and Changesets out of the box.
+
+## Workflows
+- `lint.yml`: Run Biome (`bun x biome ci .`).
+- `test.yml`: Run Vitest with coverage.
+- `typecheck.yml`: Run TypeScript project references (fallback to `--noEmit`).
+- `release.yml`: Changesets release (opens PR or publishes to npm).
+
+## Usage (in a consumer repository)
+```yaml
+name: ci
+on: [push, pull_request]
+jobs:
+  lint:      { uses: listee-dev/listee-ci/.github/workflows/lint.yml@v1 }
+  test:      { uses: listee-dev/listee-ci/.github/workflows/test.yml@v1 }
+  typecheck: { uses: listee-dev/listee-ci/.github/workflows/typecheck.yml@v1 }
+  # Release via Changesets (requires npm token in caller repo)
+  release:
+    uses: listee-dev/listee-ci/.github/workflows/release.yml@v1
+    secrets:
+      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+```
+
+Notes
+- Runners: `ubuntu-latest` recommended. External actions use stable tags (e.g., `actions/checkout@v5`).
+- The internal Bun setup is packaged as a composite action and referenced relatively for portability.
+
+## Local Development
+- Validate workflows with `act` (Apple Silicon often needs amd64):
+  - `act -j lint -W .github/workflows/lint.yml --container-architecture linux/amd64`
+  - `act -j test -W .github/workflows/test.yml --container-architecture linux/amd64`
+  - `act -j typecheck -W .github/workflows/typecheck.yml --container-architecture linux/amd64`
+- Optional: copy `actrc.example` to your system config to avoid repeating flags.
+
+## Changesets Release Flow
+- In the consumer repo, add a changeset per meaningful change: `bunx changeset` (select bump type and packages).
+- Commit the generated file under `.changeset/` and open a PR.
+- After merge to the default branch, the `release.yml` job creates a “Version Packages” PR.
+- Merge that PR to publish to npm. Requires `NPM_TOKEN` secret in the consumer repo.
+- Local preview: `bunx changeset status`. Manual flows: `bunx changeset version` then `bunx changeset publish`.
+
+## Contributing
+- Conventional Commits are encouraged (e.g., `feat(lint): strengthen Biome CI`).
+- PRs should include purpose, key changes, impact, and local verification steps.
+- Static checks run on PRs via `actionlint`.
+
+## License
+MIT License — see `LICENSE`.

--- a/actrc.example
+++ b/actrc.example
@@ -1,0 +1,5 @@
+# Default container architecture for Apple Silicon
+--container-architecture linux/amd64
+
+# Default image mapping (optional)
+-P ubuntu-latest=catthehacker/ubuntu:act-latest


### PR DESCRIPTION
This PR modernizes the reusable CI package:

- Switch reusable workflows to reference the internal composite action relatively (./.github/actions/setup-bun) so both GitHub and act work.
- Add actionlint on PR via reviewdog.
- Add AGENTS.md: contributor guide.
- Add actrc.example for Apple Silicon defaults.
- Update README with usage, local dev, badges, and Changesets flow.
- Add the missing setup-bun composite action.

Notes:
- Consumers should keep using @v1 tags when referencing these workflows.
- actionlint runs on PRs and annotates findings via GitHub Checks.
