### PR TITLE
chore: add pinact enforcement

### DIFF
--- a/.github/actions/setup-bun/action.yml
+++ b/.github/actions/setup-bun/action.yml
@@ -3,7 +3,7 @@ description: "Installs Bun and dependencies with frozen lockfile"
 runs:
   using: "composite"
   steps:
-    - uses: oven-sh/setup-bun@v2
+    - uses: oven-sh/setup-bun@735343b667d3e6f658f44d0eca948eb6282f2b76 # v2.0.2
     - name: Install deps (frozen)
       shell: bash
       run: bun install --frozen-lockfile

--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -9,6 +9,7 @@ on:
 permissions:
   contents: read
   pull-requests: read
+  checks: write
 jobs:
   actionlint:
     runs-on: ubuntu-latest

--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -2,6 +2,9 @@ name: actionlint
 on:
   pull_request:
     paths:
+permissions:
+  contents: read
+  pull-requests: read
       - ".github/workflows/*.yml"
       - ".github/workflows/*.yaml"
       - ".github/actions/**"
@@ -11,6 +14,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
       - name: Run actionlint
         uses: reviewdog/action-actionlint@95395aac8c053577d0bc67eb7b74936c660c6f66 # v1.67.0
         with:

--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -10,9 +10,9 @@ jobs:
   actionlint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       - name: Run actionlint
-        uses: reviewdog/action-actionlint@v1
+        uses: reviewdog/action-actionlint@95395aac8c053577d0bc67eb7b74936c660c6f66 # v1.67.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           reporter: github-pr-check

--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -2,13 +2,13 @@ name: actionlint
 on:
   pull_request:
     paths:
-permissions:
-  contents: read
-  pull-requests: read
       - ".github/workflows/*.yml"
       - ".github/workflows/*.yaml"
       - ".github/actions/**"
       - "AGENTS.md"
+permissions:
+  contents: read
+  pull-requests: read
 jobs:
   actionlint:
     runs-on: ubuntu-latest

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,6 +5,6 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       - uses: ./.github/actions/setup-bun
       - run: bun x biome ci .

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,10 +1,14 @@
 name: lint
 on:
   workflow_call:
+permissions:
+  contents: read
 jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/setup-bun
       - run: bun x biome ci .

--- a/.github/workflows/pinact.yml
+++ b/.github/workflows/pinact.yml
@@ -1,0 +1,24 @@
+name: pinact
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  pinact:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
+      - name: Validate pinned actions
+        uses: suzuki-shunsuke/pinact-action@49cbd6acd0dbab6a6be2585d1dbdaa43b4410133 # v1.0.0
+        with:
+          skip_push: "true"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,10 +11,10 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       - uses: ./.github/actions/setup-bun
       - name: Create Release PR or Publish
-        uses: changesets/action@v1
+        uses: changesets/action@e0145edc7d9d8679003495b11f87bd8ef63c0cba # v1.5.3
         with:
           version: bunx changeset version
           publish: bunx changeset publish

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/setup-bun
       - name: Create Release PR or Publish
         uses: changesets/action@e0145edc7d9d8679003495b11f87bd8ef63c0cba # v1.5.3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       - uses: ./.github/actions/setup-bun
       - name: Vitest
         run: bun x vitest run --coverage

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,11 +1,15 @@
 name: test
 on:
   workflow_call:
+permissions:
+  contents: read
 jobs:
   test:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/setup-bun
       - name: Vitest
         run: bun x vitest run --coverage

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -1,11 +1,15 @@
 name: typecheck
 on:
   workflow_call:
+permissions:
+  contents: read
 jobs:
   typecheck:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/setup-bun
       - name: TypeScript (noEmit fallback)
         run: bun x tsc -b || bun x tsc --noEmit

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -5,7 +5,7 @@ jobs:
   typecheck:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       - uses: ./.github/actions/setup-bun
       - name: TypeScript (noEmit fallback)
         run: bun x tsc -b || bun x tsc --noEmit

--- a/.pinact.yaml
+++ b/.pinact.yaml
@@ -1,0 +1,14 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/suzuki-shunsuke/pinact/refs/heads/main/json-schema/pinact.json
+# pinact - https://github.com/suzuki-shunsuke/pinact
+version: 3
+# files:
+#   - pattern: action.yaml
+#   - pattern: */action.yaml
+
+ignore_actions:
+# - name: slsa-framework/slsa-github-generator/\.github/workflows/generator_generic_slsa3\.yml
+#   ref: v\d+\.\d+\.\d+
+# - name: actions/.*
+#   ref: main
+# - name: suzuki-shunsuke/.*
+#   ref: release-.*

--- a/.pinact.yaml
+++ b/.pinact.yaml
@@ -5,7 +5,7 @@ version: 3
 #   - pattern: action.yaml
 #   - pattern: */action.yaml
 
-ignore_actions:
+ignore_actions: []
 # - name: slsa-framework/slsa-github-generator/\.github/workflows/generator_generic_slsa3\.yml
 #   ref: v\d+\.\d+\.\d+
 # - name: actions/.*

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,7 @@
   - `act -j test -W .github/workflows/test.yml --container-architecture linux/amd64`
   - `act -j typecheck -W .github/workflows/typecheck.yml --container-architecture linux/amd64`
 - Optional static analysis: `actionlint`.
+- Pin verification: run `pinact run --check` locally or via the `pinact.yml` workflow.
 
 ## Local act Configuration
 - Copy `actrc.example` to your OS‑specific config to omit the architecture flag:
@@ -40,4 +41,4 @@
 
 ## Security and Configuration Notes
 - `release.yml` requires the `NPM_TOKEN` to be provided by the caller. Permissions are minimized to `contents` and `pull-requests`.
-- Do not log sensitive information. Using stable tags helps reduce supply chain risks.
+- Do not log sensitive information. Using stable tags helps reduce supply chain risks; `pinact` enforcement ensures commits stay pinned.

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Reusable GitHub Actions workflows for the listee-dev organization — Bun, Biome
 - `test.yml`: Run Vitest with coverage.
 - `typecheck.yml`: Run TypeScript project references (fallback to `--noEmit`).
 - `release.yml`: Changesets release (opens PR or publishes to npm).
+- `pinact.yml`: Validate that reusable workflows reference full-length commit SHAs.
 
 ## Usage (in a consumer repository)
 ```yaml
@@ -27,7 +28,7 @@ jobs:
 ```
 
 Notes
-- Runners: `ubuntu-latest` recommended. External actions use stable tags (e.g., `actions/checkout@v5`).
+- Runners: `ubuntu-latest` recommended. External actions are pinned to full-length commit SHAs via `pinact` to mitigate tag rewrite attacks.
 - The internal Bun setup is packaged as a composite action and referenced relatively for portability.
 
 ## Local Development
@@ -35,6 +36,7 @@ Notes
   - `act -j lint -W .github/workflows/lint.yml --container-architecture linux/amd64`
   - `act -j test -W .github/workflows/test.yml --container-architecture linux/amd64`
   - `act -j typecheck -W .github/workflows/typecheck.yml --container-architecture linux/amd64`
+  - `act -j pinact -W .github/workflows/pinact.yml --container-architecture linux/amd64`
 - Optional: copy `actrc.example` to your system config to avoid repeating flags.
 
 ## Changesets Release Flow


### PR DESCRIPTION
## Summary
- pin all reusable workflows to commit SHAs with pinact
- add pinact validation workflow to CI and document the requirement
- update repository docs with local pinact guidance

## Testing
- act -j pinact -W .github/workflows/pinact.yml --container-architecture linux/amd64

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Chores
  - Pinned external CI actions to specific commits, added a CI workflow to validate pinned actions, and standardized checkout credential handling and workflow permissions to improve supply-chain security and reproducible CI.
- Documentation
  - Updated README and AGENTS guide with the new pin verification workflow, local validation commands, and guidance on using pinned SHAs and related security practices.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->