### PR TITLE
chore: make pinact failure actionable

### DIFF
--- a/.github/workflows/pinact.yml
+++ b/.github/workflows/pinact.yml
@@ -9,6 +9,7 @@ on:
 permissions:
   contents: read
   pull-requests: read
+  checks: write
 
 jobs:
   pinact:
@@ -19,6 +20,18 @@ jobs:
         with:
           persist-credentials: false
       - name: Validate pinned actions
+        id: pinact
+        continue-on-error: true
         uses: suzuki-shunsuke/pinact-action@49cbd6acd0dbab6a6be2585d1dbdaa43b4410133 # v1.0.0
         with:
           skip_push: "true"
+        # pinact-action reports results via GitHub check; we interpret outcome below
+      - name: Suggest remediation when pinact fails
+        if: steps.pinact.outcome == "failure"
+        run: |
+          echo '::error::Some GitHub Actions are not pinned to commit SHAs.'
+          echo '::error::Fix steps:'
+          echo '::error::1. Install pinact (brew install pinact).'
+          echo '::error::2. Run \`pinact run\` or \`pinact run -u\` locally to update SHAs.'
+          echo '::error::3. Commit the changes and push again.'
+          exit 1


### PR DESCRIPTION
## Summary
- run pinact validation with continue-on-error to inspect the outcome
- emit remediation instructions when pinact finds non-pinned actions
- ensure pinact workflow has checks: write permission for reviewdog output

## Testing
- pinact run --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated checks to use appropriate write permissions.
  * Improved error handling: workflows now surface clear, actionable messages when a step fails and will correctly fail the run afterward.
  * Added step identifiers to enhance traceability in check logs.
  * Maintains existing behavior for skipping pushes when applicable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->