### PR TITLE
chore: adopt npm trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,20 +1,29 @@
 name: release
 on:
   workflow_call:
-    secrets:
-      NPM_TOKEN:
-        required: true
+    inputs:
+      environment:
+        description: "GitHub environment to target for npm trusted publishing"
+        required: false
+        default: production
 permissions:
   contents: write
   pull-requests: write
+  id-token: write
 jobs:
   release:
     runs-on: ubuntu-latest
+    environment: ${{ inputs.environment }}
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           persist-credentials: false
       - uses: ./.github/actions/setup-bun
+      - name: Ensure npm 11.5.1+
+        run: |
+          corepack enable
+          corepack prepare npm@11.5.1 --activate
+          npm --version
       - name: Create Release PR or Publish
         uses: changesets/action@e0145edc7d9d8679003495b11f87bd8ef63c0cba # v1.5.3
         with:
@@ -22,4 +31,3 @@ jobs:
           publish: bunx changeset publish
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,5 +40,5 @@
 - PRs should include purpose, key changes, impact scope, and verification instructions (`act` command examples). Link relevant issues.
 
 ## Security and Configuration Notes
-- `release.yml` requires the `NPM_TOKEN` to be provided by the caller. Permissions are minimized to `contents` and `pull-requests`.
+- `release.yml` uses npm Trusted Publishing (OIDC). Ensure the target repository/environment is registered as a Trusted Publisher and grants `id-token` permission.
 - Do not log sensitive information. Using stable tags helps reduce supply chain risks; `pinact` enforcement ensures commits stay pinned.

--- a/README.md
+++ b/README.md
@@ -23,12 +23,13 @@ jobs:
   # Release via Changesets (requires npm token in caller repo)
   release:
     uses: listee-dev/listee-ci/.github/workflows/release.yml@v1
-    secrets:
-      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+    with:
+      environment: production
 ```
 
 Notes
 - Runners: `ubuntu-latest` recommended. External actions are pinned to full-length commit SHAs via `pinact` to mitigate tag rewrite attacks.
+- npm releases use Trusted Publishing (OIDC); ensure you whitelist the workflow + environment in npm and no `NPM_TOKEN` secret is required.
 - The internal Bun setup is packaged as a composite action and referenced relatively for portability.
 
 ## Local Development
@@ -43,7 +44,7 @@ Notes
 - In the consumer repo, add a changeset per meaningful change: `bunx changeset` (select bump type and packages).
 - Commit the generated file under `.changeset/` and open a PR.
 - After merge to the default branch, the `release.yml` job creates a “Version Packages” PR.
-- Merge that PR to publish to npm. Requires `NPM_TOKEN` secret in the consumer repo.
+- Merge that PR to publish to npm. Configure npm Trusted Publishing for the repository/environment instead of providing `NPM_TOKEN`.
 - Local preview: `bunx changeset status`. Manual flows: `bunx changeset version` then `bunx changeset publish`.
 
 ## Contributing


### PR DESCRIPTION
## Summary
- drop NPM_TOKEN from the reusable release workflow and require id-token permission
- ensure npm 11.5.1+ is available before running changesets publish
- document the npm Trusted Publishing setup for consumers

## Testing
- pinact run --check