### PR TITLE
chore: fix workflow-call schema issues

### DIFF
--- a/.github/workflows/pinact.yml
+++ b/.github/workflows/pinact.yml
@@ -27,7 +27,7 @@ jobs:
           skip_push: "true"
         # pinact-action reports results via GitHub check; we interpret outcome below
       - name: Suggest remediation when pinact fails
-        if: steps.pinact.outcome == "failure"
+        if: steps.pinact.outcome == 'failure'
         run: |
           echo '::error::Some GitHub Actions are not pinned to commit SHAs.'
           echo '::error::Fix steps:'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,7 @@ on:
   workflow_call:
     inputs:
       environment:
+        type: string
         description: "GitHub environment to target for npm trusted publishing"
         required: false
         default: production


### PR DESCRIPTION
## Summary
- add missing type to release workflow_call input
- use single quotes in pinact failure expression to satisfy workflow syntax

## Testing
- act -j actionlint -W .github/workflows/actionlint.yml --container-architecture linux/amd64 (expected reviewdog 404 in act but syntax checked)
- pinact run --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Standardized workflow condition syntax to improve consistency (no behavior change).
  * Explicitly declared the release workflow’s "environment" input as a string to strengthen validation and make runs more predictable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->