### PR TITLE
chore(ci): update setup-bun pin after merge

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,5 +10,5 @@ jobs:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           persist-credentials: false
-      - uses: listee-dev/listee-ci/.github/actions/setup-bun@c8346825c9f76c2b3c21e9b4a04fbb9a4c3c5c4c
+      - uses: listee-dev/listee-ci/.github/actions/setup-bun@e8b9cc21a4dfec25715dddccfd2b1269dba69dab
       - run: bun x biome ci .

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           persist-credentials: false
-      - uses: listee-dev/listee-ci/.github/actions/setup-bun@c8346825c9f76c2b3c21e9b4a04fbb9a4c3c5c4c
+      - uses: listee-dev/listee-ci/.github/actions/setup-bun@e8b9cc21a4dfec25715dddccfd2b1269dba69dab
       - name: Install dependencies
         run: bun install --frozen-lockfile
       - name: Install latest npm

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           persist-credentials: false
-      - uses: listee-dev/listee-ci/.github/actions/setup-bun@c8346825c9f76c2b3c21e9b4a04fbb9a4c3c5c4c
+      - uses: listee-dev/listee-ci/.github/actions/setup-bun@e8b9cc21a4dfec25715dddccfd2b1269dba69dab
       - name: Bun build
         run: bun run build
       - name: Bun test

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -10,6 +10,6 @@ jobs:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           persist-credentials: false
-      - uses: listee-dev/listee-ci/.github/actions/setup-bun@c8346825c9f76c2b3c21e9b4a04fbb9a4c3c5c4c
+      - uses: listee-dev/listee-ci/.github/actions/setup-bun@e8b9cc21a4dfec25715dddccfd2b1269dba69dab
       - name: TypeScript (noEmit fallback)
         run: bun x tsc -b || bun x tsc --noEmit


### PR DESCRIPTION
## Summary
- Update setup-bun pin in workflows to the latest main commit

## Verification
- act -j lint -W .github/workflows/lint.yml --container-architecture linux/amd64


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow infrastructure to use a newer version of the Bun setup action across all deployment pipelines.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->